### PR TITLE
Return .mjs files with application/javascript mime type

### DIFF
--- a/devserver_lib/src/lib.rs
+++ b/devserver_lib/src/lib.rs
@@ -413,6 +413,7 @@ fn extension_to_mime_impl(extension: Option<&str>) -> &'static str {
         Some("mid") => "audio/mid",
         Some("midi") => "audio/mid",
         Some("mix") => "application/octet-stream",
+        Some("mjs") => "application/javascript",
         Some("mk") => "text/plain; charset=utf8",
         Some("mmf") => "application/x-smaf",
         Some("mno") => "application/xml",


### PR DESCRIPTION
Hi, thanks for the excellent little tool you have built here.

I had a need to serve `.mjs` for javascript module files. Some background on why this is done sometimes here:

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules#Aside_%E2%80%94_.mjs_versus_.js

Cheers. 