### PR TITLE
Fix panic if < 4 bytes are read from stream

### DIFF
--- a/devserver_lib/src/lib.rs
+++ b/devserver_lib/src/lib.rs
@@ -24,7 +24,7 @@ pub fn read_header<T: Read + Write>(stream: &mut T) -> Vec<u8> {
     loop {
         reader.read_until(b'\n', &mut buffer).unwrap();
         // Read until end of header.
-        if &buffer[buffer.len() - 4..] == b"\r\n\r\n" {
+        if buffer.len() >= 4 && &buffer[buffer.len() - 4..] == b"\r\n\r\n" {
             break;
         }
     }

--- a/devserver_lib/src/lib.rs
+++ b/devserver_lib/src/lib.rs
@@ -24,7 +24,7 @@ pub fn read_header<T: Read + Write>(stream: &mut T) -> Vec<u8> {
     loop {
         reader.read_until(b'\n', &mut buffer).unwrap();
         // Read until end of header.
-        if buffer.len() >= 4 && &buffer[buffer.len() - 4..] == b"\r\n\r\n" {
+        if buffer.ends_with(b"\r\n\r\n") {
             break;
         }
     }


### PR DESCRIPTION
I hit this panic on my machine once:
```
thread '<unnamed>' panicked at 'range start index 18446744073709551612 out of range for slice of length 0', /home/rukai/.cargo/registry/src/github.com-1ecc6299db9ec823/devserver_lib-0.4.1/src/lib.rs:27:13
stack backtrace:
   0: rust_begin_unwind
             at /rustc/f1edd0429582dd29cccacaf50fd134b05593bd9c/library/std/src/panicking.rs:517:5
   1: core::panicking::panic_fmt
             at /rustc/f1edd0429582dd29cccacaf50fd134b05593bd9c/library/core/src/panicking.rs:100:14
   2: core::slice::index::slice_start_index_len_fail
             at /rustc/f1edd0429582dd29cccacaf50fd134b05593bd9c/library/core/src/slice/index.rs:34:5
   3: devserver_lib::handle_client
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

I believe it occurs when the we reach this point before receiving data from the client.

By using `slice::ends_with` we avoid the panic due to its internal length check.