### PR TITLE
ci(github-actions): add GitHub Actions workflow to create GitHub Release

### DIFF
--- a/.github/workflows/create_gh_release.yml
+++ b/.github/workflows/create_gh_release.yml
@@ -1,0 +1,45 @@
+name: Create GitHub release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: write
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Release
+        uses: softprops/action-gh-release@v1
+
+  upload-assets:
+    needs: create-release
+
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/upload-rust-binary-action@v1
+        with:
+          bin: devserver
+          target: ${{ matrix.target }}
+          archive: devserver-$target
+          checksum: sha512
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
First of all, Thanks for creating this awesome tool.

This PR adds a GitHub Actions workflow to create a GitHub Release.
The created GitHub Release has binaries as assets.

The reason for creating this PR, I would like to download `devserver` via [aqua](https://aquaproj.github.io) without using cargo.

- A test release
  https://github.com/hituzi-no-sippo/devserver/releases/tag/v0.4.3
- A Result of GitHub Actions to create a test release
  https://github.com/hituzi-no-sippo/devserver/actions/runs/7160164469
